### PR TITLE
Propagate `Host` header from the original request

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-FROM golang:1.16-alpine
+FROM golang:1.16-alpine as build
 
 WORKDIR /app
 
@@ -11,5 +11,8 @@ RUN go mod download
 COPY *.go ./
 
 RUN GOOS=linux GOARCH=amd64 go build -o /tired-proxy
+
+from scratch
+copy --from=build /tired-proxy /
 
 CMD [ "/tired-proxy" ]

--- a/main.go
+++ b/main.go
@@ -47,8 +47,6 @@ func main() {
 		return func(w http.ResponseWriter, r *http.Request) {
 			idle.timer.Reset(idle.idle)
 			log.Println(r.URL)
-			r.Host = remote.Host
-			w.Header().Set("X-Ben", "Rad")
 			p.ServeHTTP(w, r)
 		}
 	}


### PR DESCRIPTION
The current code sets the `Host` header (respectively `:authority` for HTTP/2) to the host name set by the `-host` parameter. This however breaks certain setups, which might expect the Host header to be retained.

In my particular case, I have `tired-proxy` in front of `traefik` which is used to configure different access rules depending on the Host used.

I expect the original code had some particular intention, but it's unclear what use cases it serves. Hopefully this PR helps other people figure out what's happening faster :)